### PR TITLE
Fix refspec used for candlepin checkouts

### DIFF
--- a/ansible/roles/candlepin-user/tasks/checkout.yml
+++ b/ansible/roles/candlepin-user/tasks/checkout.yml
@@ -12,6 +12,7 @@
     force: yes
     version: "{{candlepin_branch}}"
     refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+    clone: yes
   when: candlepin_git_pull == True
 
 - name: Checkout Caracalla

--- a/ansible/roles/candlepin-user/tasks/checkout.yml
+++ b/ansible/roles/candlepin-user/tasks/checkout.yml
@@ -5,7 +5,7 @@
     dest: "{{candlepin_checkout}}"
     force: yes
     version: "{{candlepin_branch}}"
-#    refspec: '+refs/pull/*:refs/heads/*'
+    refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
   when: candlepin_git_pull == True
 
 - name: Checkout Caracalla

--- a/ansible/roles/candlepin-user/tasks/checkout.yml
+++ b/ansible/roles/candlepin-user/tasks/checkout.yml
@@ -1,4 +1,10 @@
 ---
+- name: Clean Candlepin Checkout
+  file:
+      state: absent
+      path: "{{candlepin_checkout}}"
+  when: candlepin_git_pull == True
+
 - name: Checkout Candlepin
   git:
     repo: "{{candlepin_git_repo}}"

--- a/ansible/roles/hypervisor/tasks/main.yml
+++ b/ansible/roles/hypervisor/tasks/main.yml
@@ -10,7 +10,7 @@
     state=stopped
 
 - name: Reset snapshot on performance vm (readyfortestsnap snapshot)
-  command: virsh snapshot-revert --domain {{perf_vm_domain}} --snapshotname='readyfortestsnap_csnyder' --running
+  command: virsh snapshot-revert --domain {{perf_vm_domain}} --snapshotname='readyfortestsnap' --running
   when:
     - perf_vm_domain == "CP" or (perf_vm_domain == "candlepin-perf-mysql" and target_branch == "master")
   tags:

--- a/ansible/roles/hypervisor/tasks/main.yml
+++ b/ansible/roles/hypervisor/tasks/main.yml
@@ -10,7 +10,7 @@
     state=stopped
 
 - name: Reset snapshot on performance vm (readyfortestsnap snapshot)
-  command: virsh snapshot-revert --domain {{perf_vm_domain}} --snapshotname='readyfortestsnap' --running
+  command: virsh snapshot-revert --domain {{perf_vm_domain}} --snapshotname='readyfortestsnap_csnyder' --running
   when:
     - perf_vm_domain == "CP" or (perf_vm_domain == "candlepin-perf-mysql" and target_branch == "master")
   tags:


### PR DESCRIPTION
This PR does a few things:
- Changes the refspec used to checkout candlepin branches.
- Cleans (deletes) the existing candlepin checkout before checkout out a new one on the appropriate branch
- Clones the candlepin repo fresh.

This is done to ensure a clean checkout each time and that the refspec used to refer to merge commits matches that used by jenkins (presently).