### PR TITLE
Add histogram creation to parse-jtl.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib


### PR DESCRIPTION
Update parse-jtl.py to add the ability to generate graphs of the distributions of the results for each of the calls. This adds numpy & matplotlib as requirements in order to both perform the calculations & generate the graphs. 